### PR TITLE
Demo usecase of using Kotlin objects with mutable state

### DIFF
--- a/app/src/main/java/com/segunfamisa/zeitung/ui/common/MainScreen.kt
+++ b/app/src/main/java/com/segunfamisa/zeitung/ui/common/MainScreen.kt
@@ -11,27 +11,11 @@ import androidx.ui.layout.Column
 import androidx.ui.layout.Row
 import androidx.ui.material.BottomNavigation
 import androidx.ui.material.BottomNavigationItem
-import androidx.ui.res.stringResource
-import androidx.ui.res.vectorResource
-import com.segunfamisa.zeitung.R
 import com.segunfamisa.zeitung.ui.theme.secondary
 
 
 @Composable
-private val navItems: List<NavItem>
-    get() = listOf(
-        NavItem(
-            0,
-            stringResource(id = R.string.menu_news),
-            vectorResource(id = R.drawable.ic_nav_menu_newspaper)
-        ),
-
-        NavItem(
-            1,
-            stringResource(id = R.string.menu_bookmarks),
-            vectorResource(id = R.drawable.ic_nav_menu_bookmark)
-        )
-    )
+private val navItems = listOf(NavItem.News, NavItem.Saved)
 
 @Composable
 fun MainContent(

--- a/app/src/main/java/com/segunfamisa/zeitung/ui/common/MainScreen.kt
+++ b/app/src/main/java/com/segunfamisa/zeitung/ui/common/MainScreen.kt
@@ -13,16 +13,12 @@ import androidx.ui.material.BottomNavigation
 import androidx.ui.material.BottomNavigationItem
 import com.segunfamisa.zeitung.ui.theme.secondary
 
-
-@Composable
-private val navItems = listOf(NavItem.News, NavItem.Saved)
-
 @Composable
 fun MainContent(
-    items: List<NavItem> = navItems,
-    state: NavBarState = NavBarState(navItems[0]),
     onItemSelected: (NavItem) -> Boolean
 ) {
+    val items = listOf(NavItem.News, NavItem.Saved)
+    val state = NavBarState(items.first())
     Column {
         Row(modifier = Modifier.weight(1f)) {
             // TODO body corresponding to each selection goes here

--- a/app/src/main/java/com/segunfamisa/zeitung/ui/common/NavBarState.kt
+++ b/app/src/main/java/com/segunfamisa/zeitung/ui/common/NavBarState.kt
@@ -4,8 +4,23 @@ import androidx.compose.getValue
 import androidx.compose.mutableStateOf
 import androidx.compose.setValue
 import androidx.ui.graphics.vector.VectorAsset
+import androidx.ui.res.stringResource
+import androidx.ui.res.vectorResource
+import com.segunfamisa.zeitung.R
 
-class NavItem(val index: Int, val title: String, val icon: VectorAsset)
+sealed class NavItem(val index: Int, val title: String, val icon: VectorAsset) {
+    object News : NavItem(
+        0,
+        stringResource(id = R.string.menu_news),
+        vectorResource(id = R.drawable.ic_nav_menu_newspaper)
+    )
+
+    object Saved : NavItem(
+        1,
+        stringResource(id = R.string.menu_bookmarks),
+        vectorResource(id = R.drawable.ic_nav_menu_bookmark)
+    )
+}
 
 class NavBarState(initialSelection: NavItem) {
     var currentSelection by mutableStateOf<NavItem>(initialSelection)


### PR DESCRIPTION
It seems like I can't use Kotlin objects with compose `mutableStateOf()`.

This line stood out to me: `Caused by: java.lang.AssertionError: Object should have a primary constructor: News`. News is an object type of the NavItem sealed class. I expected that this feature would be allowed.

It fails with an error:

```
Executing tasks: [:app:assembleDebug] in project /Users/oluwasegunfamisa/Documents/private/dev/android-zeitung

WARNING: The specified Android SDK Build Tools version (28.0.3) is ignored, as it is below the minimum supported version (29.0.2) for Android Gradle Plugin 4.2.0-alpha02.
Android SDK Build Tools 29.0.2 will be used.
To suppress this warning, remove "buildToolsVersion '28.0.3'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
> Task :core:compileKotlin UP-TO-DATE
> Task :core:compileJava NO-SOURCE
> Task :core:processResources NO-SOURCE
> Task :core:classes UP-TO-DATE
> Task :core:inspectClassesForKotlinIC UP-TO-DATE
> Task :core:jar UP-TO-DATE
> Task :data:generateBuildConfig UP-TO-DATE
> Task :data:compileBuildConfig UP-TO-DATE
> Task :domain:compileKotlin UP-TO-DATE
> Task :domain:compileJava NO-SOURCE
> Task :domain:processResources NO-SOURCE
> Task :domain:classes UP-TO-DATE
> Task :domain:inspectClassesForKotlinIC UP-TO-DATE
> Task :domain:jar UP-TO-DATE
> Task :data:kaptGenerateStubsKotlin UP-TO-DATE
> Task :data:kaptKotlin UP-TO-DATE
> Task :data:compileKotlin UP-TO-DATE
> Task :data:compileJava UP-TO-DATE
> Task :data:processResources NO-SOURCE
> Task :data:classes UP-TO-DATE
> Task :data:inspectClassesForKotlinIC UP-TO-DATE
> Task :data:jar UP-TO-DATE
> Task :app:preBuild UP-TO-DATE
> Task :app:preDebugBuild UP-TO-DATE
> Task :headlines:preBuild UP-TO-DATE
> Task :headlines:preDebugBuild UP-TO-DATE
> Task :headlines:compileDebugAidl NO-SOURCE
> Task :app:compileDebugAidl NO-SOURCE
> Task :headlines:packageDebugRenderscript NO-SOURCE
> Task :app:compileDebugRenderscript NO-SOURCE
> Task :headlines:compileDebugRenderscript NO-SOURCE
> Task :headlines:dataBindingMergeDependencyArtifactsDebug UP-TO-DATE
> Task :headlines:dataBindingMergeGenClassesDebug UP-TO-DATE
> Task :headlines:generateDebugResValues UP-TO-DATE
> Task :headlines:generateDebugResources UP-TO-DATE
> Task :headlines:packageDebugResources UP-TO-DATE
> Task :headlines:dataBindingGenBaseClassesDebug UP-TO-DATE
> Task :headlines:dataBindingTriggerDebug UP-TO-DATE
> Task :headlines:generateDebugBuildConfig UP-TO-DATE
> Task :headlines:parseDebugLocalResources UP-TO-DATE
> Task :headlines:processDebugManifest UP-TO-DATE
> Task :headlines:generateDebugRFile UP-TO-DATE
> Task :headlines:prepareDebugKotlinCompileTask
> Task :headlines:compileDebugKotlin UP-TO-DATE
> Task :headlines:javaPreCompileDebug UP-TO-DATE
> Task :headlines:compileDebugJavaWithJavac UP-TO-DATE
> Task :app:dataBindingMergeDependencyArtifactsDebug UP-TO-DATE
> Task :app:dataBindingMergeGenClassesDebug UP-TO-DATE
> Task :app:generateDebugResValues UP-TO-DATE
> Task :app:generateDebugResources UP-TO-DATE
> Task :app:mergeDebugResources UP-TO-DATE
> Task :app:dataBindingGenBaseClassesDebug UP-TO-DATE
> Task :app:dataBindingTriggerDebug UP-TO-DATE
> Task :app:generateDebugBuildConfig UP-TO-DATE
> Task :app:prepareDebugKotlinCompileTask
> Task :headlines:writeDebugAarMetadata UP-TO-DATE
> Task :app:checkDebugAarMetadata UP-TO-DATE
> Task :app:createDebugCompatibleScreenManifests UP-TO-DATE
> Task :app:extractDeepLinksDebug UP-TO-DATE
> Task :headlines:extractDeepLinksDebug UP-TO-DATE
> Task :app:processDebugMainManifest UP-TO-DATE
> Task :app:processDebugManifest UP-TO-DATE
> Task :app:processDebugManifestForPackage UP-TO-DATE
> Task :headlines:compileDebugLibraryResources UP-TO-DATE
> Task :app:processDebugResources UP-TO-DATE
> Task :headlines:bundleLibCompileToJarDebug UP-TO-DATE

> Task :app:kaptGenerateStubsDebugKotlin
w: ATTENTION!
This build uses unsafe internal compiler arguments:

-XXLanguage:+NonParenthesizedAnnotationsOnFunctionalTypes

This mode is not recommended for production use,
as no stability/compatibility guarantees are given on
compiler or generated code. Use it at your own risk!

w: Runtime JAR files in the classpath have the version 1.3, which is older than the API version 1.4. Consider using the runtime of version 1.4, or pass '-api-version 1.3' explicitly to restrict the available APIs to the runtime of version 1.3. You can also pass '-language-version 1.3' instead, which will restrict not only the APIs to the specified version, but also the language features
w: /Users/oluwasegunfamisa/.gradle/caches/transforms-2/files-2.1/6f61c70cc469475818745cdf8c05fa40/jetified-kotlin-stdlib-common-1.3.72.jar: Runtime JAR file has version 1.3 which is older than required for API version 1.4
w: /Users/oluwasegunfamisa/.gradle/caches/transforms-2/files-2.1/8ee26e519ec6a26644c7e8c4582e9dd1/jetified-kotlin-stdlib-jdk7-1.3.61.jar: Runtime JAR file has version 1.3 which is older than required for API version 1.4
w: /Users/oluwasegunfamisa/.gradle/caches/transforms-2/files-2.1/950ab7654bb4cb53c6d06f80d1d4c5c0/jetified-kotlin-stdlib-1.3.72.jar: Runtime JAR file has version 1.3 which is older than required for API version 1.4
w: ATTENTION!
This build uses unsafe internal compiler arguments:

-XXLanguage:+NonParenthesizedAnnotationsOnFunctionalTypes

This mode is not recommended for production use,
as no stability/compatibility guarantees are given on
compiler or generated code. Use it at your own risk!

w: Runtime JAR files in the classpath have the version 1.3, which is older than the API version 1.4. Consider using the runtime of version 1.4, or pass '-api-version 1.3' explicitly to restrict the available APIs to the runtime of version 1.3. You can also pass '-language-version 1.3' instead, which will restrict not only the APIs to the specified version, but also the language features
w: /Users/oluwasegunfamisa/.gradle/caches/transforms-2/files-2.1/6f61c70cc469475818745cdf8c05fa40/jetified-kotlin-stdlib-common-1.3.72.jar: Runtime JAR file has version 1.3 which is older than required for API version 1.4
w: /Users/oluwasegunfamisa/.gradle/caches/transforms-2/files-2.1/8ee26e519ec6a26644c7e8c4582e9dd1/jetified-kotlin-stdlib-jdk7-1.3.61.jar: Runtime JAR file has version 1.3 which is older than required for API version 1.4
w: /Users/oluwasegunfamisa/.gradle/caches/transforms-2/files-2.1/950ab7654bb4cb53c6d06f80d1d4c5c0/jetified-kotlin-stdlib-1.3.72.jar: Runtime JAR file has version 1.3 which is older than required for API version 1.4

> Task :app:javaPreCompileDebug UP-TO-DATE
> Task :app:mergeDebugNativeDebugMetadata NO-SOURCE
> Task :app:mergeDebugShaders UP-TO-DATE
> Task :app:compileDebugShaders NO-SOURCE
> Task :app:generateDebugAssets UP-TO-DATE
> Task :headlines:mergeDebugShaders UP-TO-DATE
> Task :headlines:compileDebugShaders NO-SOURCE
> Task :headlines:generateDebugAssets UP-TO-DATE
> Task :headlines:packageDebugAssets UP-TO-DATE
> Task :app:mergeDebugAssets UP-TO-DATE
> Task :app:compressDebugAssets UP-TO-DATE
> Task :app:processDebugJavaRes NO-SOURCE
> Task :headlines:processDebugJavaRes NO-SOURCE
> Task :headlines:bundleLibResDebug UP-TO-DATE
> Task :app:checkDebugDuplicateClasses UP-TO-DATE
> Task :app:desugarDebugFileDependencies UP-TO-DATE
> Task :app:mergeExtDexDebug UP-TO-DATE
> Task :headlines:bundleLibRuntimeToJarDebug UP-TO-DATE
> Task :app:mergeDebugJniLibFolders UP-TO-DATE
> Task :app:mergeLibDexDebug UP-TO-DATE
> Task :headlines:mergeDebugJniLibFolders UP-TO-DATE
> Task :headlines:mergeDebugNativeLibs NO-SOURCE
> Task :headlines:stripDebugDebugSymbols NO-SOURCE
> Task :headlines:copyDebugJniLibsProjectOnly UP-TO-DATE
> Task :app:mergeDebugNativeLibs UP-TO-DATE
> Task :app:stripDebugDebugSymbols NO-SOURCE
> Task :app:validateSigningDebug UP-TO-DATE
> Task :app:kaptDebugKotlin

> Task :app:compileDebugKotlin FAILED
w: ATTENTION!
This build uses unsafe internal compiler arguments:

-XXLanguage:+NonParenthesizedAnnotationsOnFunctionalTypes

This mode is not recommended for production use,
as no stability/compatibility guarantees are given on
compiler or generated code. Use it at your own risk!

w: Runtime JAR files in the classpath have the version 1.3, which is older than the API version 1.4. Consider using the runtime of version 1.4, or pass '-api-version 1.3' explicitly to restrict the available APIs to the runtime of version 1.3. You can also pass '-language-version 1.3' instead, which will restrict not only the APIs to the specified version, but also the language features
e: java.lang.IllegalStateException: Backend Internal error: Exception during IR lowering
File being compiled: /Users/oluwasegunfamisa/Documents/private/dev/android-zeitung/app/src/main/java/com/segunfamisa/zeitung/ui/common/NavBarState.kt
The root cause java.lang.AssertionError was thrown at: org.jetbrains.kotlin.backend.jvm.lower.ObjectClassLowering.process(ObjectClassLowering.kt:49)
	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException(CodegenUtil.kt:247)
	at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$performByIrFile$1.invoke(PhaseBuilders.kt:181)
	at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$performByIrFile$1.invoke(PhaseBuilders.kt:170)
	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedPhaseWrapper$runBody$1.invoke(CompilerPhase.kt:128)
	at org.jetbrains.kotlin.backend.common.phaser.CompilerPhaseKt.downlevel(CompilerPhase.kt:24)
	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedPhaseWrapper.runBody(CompilerPhase.kt:127)
	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedPhaseWrapper.invoke(CompilerPhase.kt:105)
	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:30)
	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedPhaseWrapper$runBody$1.invoke(CompilerPhase.kt:128)
	at org.jetbrains.kotlin.backend.common.phaser.CompilerPhaseKt.downlevel(CompilerPhase.kt:24)
	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedPhaseWrapper.runBody(CompilerPhase.kt:127)
	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedPhaseWrapper.invoke(CompilerPhase.kt:105)
	at org.jetbrains.kotlin.backend.common.phaser.CompilerPhaseKt.invokeToplevel(CompilerPhase.kt:42)
	at org.jetbrains.kotlin.backend.jvm.JvmLower.lower(JvmLower.kt:350)
	at org.jetbrains.kotlin.backend.jvm.JvmBackendFacade.doGenerateFilesInternal$backend_jvm(JvmBackendFacade.kt:79)
	at org.jetbrains.kotlin.backend.jvm.JvmBackendFacade.doGenerateFiles(JvmBackendFacade.kt:52)
	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.generateModule(JvmIrCodegenFactory.kt:37)
	at org.jetbrains.kotlin.codegen.KotlinCodegenFacade.compileCorrectFiles(KotlinCodegenFacade.java:35)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.generate(KotlinToJVMBytecodeCompiler.kt:635)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileModules$cli(KotlinToJVMBytecodeCompiler.kt:194)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:163)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:51)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:86)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:44)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:104)
	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:346)
	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:102)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileIncrementally(IncrementalCompilerRunner.kt:240)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:90)
	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:606)
	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:99)
	at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1645)
	at sun.reflect.GeneratedMethodAccessor104.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:357)
	at sun.rmi.transport.Transport$1.run(Transport.java:200)
	at sun.rmi.transport.Transport$1.run(Transport.java:197)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.rmi.transport.Transport.serviceCall(Transport.java:196)
	at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:573)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:834)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:688)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:687)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.AssertionError: Object should have a primary constructor: News
	at org.jetbrains.kotlin.backend.jvm.lower.ObjectClassLowering.process(ObjectClassLowering.kt:49)
	at org.jetbrains.kotlin.backend.jvm.lower.ObjectClassLowering.visitClassNew(ObjectClassLowering.kt:37)
	at org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext.visitClass(IrElementTransformerVoidWithContext.kt:45)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:53)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:24)
	at org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl.accept(IrClassImpl.kt:93)
	at org.jetbrains.kotlin.ir.declarations.IrDeclaration$DefaultImpls.transform(IrDeclaration.kt:42)
	at org.jetbrains.kotlin.ir.declarations.impl.IrDeclarationBase.transform(IrDeclarationBase.kt:27)
	at org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl.transformChildren(IrClassImpl.kt:104)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoidKt.transformChildrenVoid(IrElementTransformerVoid.kt:288)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.transformChildrenVoid(IrElementTransformerVoid.kt:283)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.transformChildren(IrElementTransformerVoid.kt:25)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitDeclaration(IrElementTransformerVoid.kt:46)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:52)
	at org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext.visitClassNew(IrElementTransformerVoidWithContext.kt:97)
	at org.jetbrains.kotlin.backend.jvm.lower.ObjectClassLowering.visitClassNew(ObjectClassLowering.kt:38)
	at org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext.visitClass(IrElementTransformerVoidWithContext.kt:45)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:53)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:24)
	at org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl.accept(IrClassImpl.kt:93)
	at org.jetbrains.kotlin.ir.declarations.IrDeclaration$DefaultImpls.transform(IrDeclaration.kt:42)
	at org.jetbrains.kotlin.ir.declarations.impl.IrDeclarationBase.transform(IrDeclarationBase.kt:27)
	at org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl.transformChildren(IrFileImpl.kt:71)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoidKt.transformChildrenVoid(IrElementTransformerVoid.kt:288)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.transformChildrenVoid(IrElementTransformerVoid.kt:283)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.transformChildren(IrElementTransformerVoid.kt:25)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitPackageFragment(IrElementTransformerVoid.kt:34)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:37)
	at org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext.visitFileNew(IrElementTransformerVoidWithContext.kt:93)
	at org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext.visitFile(IrElementTransformerVoidWithContext.kt:38)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:38)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:24)
	at org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl.accept(IrFileImpl.kt:63)
	at org.jetbrains.kotlin.backend.jvm.lower.ObjectClassLowering.lower(ObjectClassLowering.kt:31)
	at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$makeIrFilePhase$1.invoke(PhaseBuilders.kt:211)
	at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$makeIrFilePhase$1.invoke(PhaseBuilders.kt:209)
	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedPhaseWrapper$runBody$1.invoke(CompilerPhase.kt:128)
	at org.jetbrains.kotlin.backend.common.phaser.CompilerPhaseKt.downlevel(CompilerPhase.kt:24)
	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedPhaseWrapper.runBody(CompilerPhase.kt:127)
	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedPhaseWrapper.invoke(CompilerPhase.kt:105)
	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:30)
	at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$performByIrFile$1.invoke(PhaseBuilders.kt:179)
	... 46 more

w: /Users/oluwasegunfamisa/.gradle/caches/transforms-2/files-2.1/6f61c70cc469475818745cdf8c05fa40/jetified-kotlin-stdlib-common-1.3.72.jar: Runtime JAR file has version 1.3 which is older than required for API version 1.4
w: /Users/oluwasegunfamisa/.gradle/caches/transforms-2/files-2.1/8ee26e519ec6a26644c7e8c4582e9dd1/jetified-kotlin-stdlib-jdk7-1.3.61.jar: Runtime JAR file has version 1.3 which is older than required for API version 1.4
w: /Users/oluwasegunfamisa/.gradle/caches/transforms-2/files-2.1/950ab7654bb4cb53c6d06f80d1d4c5c0/jetified-kotlin-stdlib-1.3.72.jar: Runtime JAR file has version 1.3 which is older than required for API version 1.4

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:compileDebugKotlin'.
> Internal compiler error. See log for more details

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s
67 actionable tasks: 5 executed, 62 up-to-date

```
