### PR TITLE
Onboarding - Implement navigation from onboarding to the main app

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation("androidx.ui:ui-tooling:$libs.composeVersion")
     implementation("androidx.compose.ui:ui:$libs.composeVersion")
     implementation("androidx.compose.runtime:runtime-livedata:$libs.composeVersion")
+    implementation("androidx.navigation:navigation-compose:$libs.navigationVersion")
 
     implementation("dev.chrisbanes.accompanist:accompanist-coil:$libs.accompanistVersion")
 

--- a/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/BottomNavBar.kt
+++ b/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/BottomNavBar.kt
@@ -6,71 +6,59 @@ import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.KEY_ROUTE
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.navigate
 import com.segunfamisa.zeitung.R
 import com.segunfamisa.zeitung.common.theme.colors
 
-sealed class NavItem(val index: Int, @StringRes val title: Int, @DrawableRes val icon: Int) {
-    object News : NavItem(0, R.string.menu_news, R.drawable.ic_nav_menu_newspaper)
-    object Explore : NavItem(1, R.string.menu_browse, R.drawable.ic_nav_menu_browse)
-    object Bookmarks : NavItem(2, R.string.menu_bookmarks, R.drawable.ic_nav_menu_bookmark)
-}
-
-class NavBarState(val navItems: List<NavItem>, defaultSelectedIndex: Int = 0) {
-    var currentSelection by mutableStateOf(navItems[defaultSelectedIndex])
-        private set
-
-    fun update(newSelection: NavItem) {
-        currentSelection = newSelection
-    }
+sealed class NavItem(
+    @StringRes val title: Int,
+    @DrawableRes val icon: Int,
+    val route: String
+) {
+    object News : NavItem(R.string.menu_news, R.drawable.ic_nav_menu_newspaper, Routes.News)
+    object Explore : NavItem(R.string.menu_browse, R.drawable.ic_nav_menu_browse, Routes.Explore)
+    object Bookmarks :
+        NavItem(R.string.menu_bookmarks, R.drawable.ic_nav_menu_bookmark, Routes.Bookmarks)
 }
 
 @Composable
 fun BottomNavBar(
-    state: NavBarState,
-    onItemSelected: (NavItem) -> Boolean
+    navController: NavHostController,
+    items: List<NavItem>
 ) {
-    var shouldSelectInitialNavItem: Boolean = remember { true }
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.arguments?.getString(KEY_ROUTE)
     BottomNavigation {
-        state.navItems.forEach { navItem ->
-            val isSelected = navItem.index == state.currentSelection.index
+        items.forEach { navItem ->
+            val isSelected = currentRoute == navItem.route
             BottomNavigationItem(
-                icon = { BottomNavIcon(navItem, isSelected) },
+                icon = { BottomNavIcon(navItem) },
                 label = { BottomNavText(navItem, isSelected) },
                 selected = isSelected,
                 alwaysShowLabels = true,
                 selectedContentColor = colors().secondary,
                 onClick = {
-                    // We want to avoid reselection. In the future, I may provide item reselection
-                    // callbacks. But for now, no need.
-                    if (!isSelected) {
-                        val selected = onItemSelected(navItem)
-                        if (selected) {
-                            state.update(navItem)
-                        }
-                        // we no longer need to set initial item since the callback is triggered
-                        shouldSelectInitialNavItem = false
+                    if (currentRoute != navItem.route) {
+                        navController.navigate(route = navItem.route)
                     }
                 }
             )
-
-            // automatically trigger "selection" for default selection
-            // if we haven't done so already
-            if (shouldSelectInitialNavItem && isSelected) {
-                onItemSelected(navItem)
-            }
         }
     }
 }
 
 @Composable
 private fun BottomNavIcon(
-    navItem: NavItem,
-    isSelected: Boolean
+    navItem: NavItem
 ) {
     Icon(
         asset = vectorResource(id = navItem.icon),

--- a/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/MainActivity.kt
+++ b/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/MainActivity.kt
@@ -1,31 +1,48 @@
 package com.segunfamisa.zeitung.ui.common
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.ViewModelLazy
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigate
+import androidx.navigation.compose.rememberNavController
 import com.segunfamisa.zeitung.R
 import com.segunfamisa.zeitung.common.theme.ZeitungTheme
 import com.segunfamisa.zeitung.news.NewsContent
 import com.segunfamisa.zeitung.news.NewsViewModel
+import com.segunfamisa.zeitung.onboarding.OnboardingContent
+import com.segunfamisa.zeitung.onboarding.OnboardingViewModel
 import com.segunfamisa.zeitung.util.viewmodel.ViewModelFactory
 import javax.inject.Inject
 
 class MainActivity : AppCompatActivity() {
 
     @Inject
-    lateinit var viewModelFactory: ViewModelFactory<NewsViewModel>
+    lateinit var newsViewModelFactory: ViewModelFactory<NewsViewModel>
+
+    @Inject
+    lateinit var onboardingViewModelFactory: ViewModelFactory<OnboardingViewModel>
 
     private val newsViewModelLazy: Lazy<NewsViewModel> = ViewModelLazy(
         viewModelClass = NewsViewModel::class,
         storeProducer = { viewModelStore },
-        factoryProducer = { viewModelFactory }
+        factoryProducer = { newsViewModelFactory }
+    )
+
+    private val onboardingViewModelLazy: Lazy<OnboardingViewModel> = ViewModelLazy(
+        viewModelClass = OnboardingViewModel::class,
+        storeProducer = { viewModelStore },
+        factoryProducer = { onboardingViewModelFactory }
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -40,54 +57,67 @@ class MainActivity : AppCompatActivity() {
 
     @Composable
     private fun App() {
-        val navBarState = NavBarState(listOf(NavItem.News, NavItem.Explore, NavItem.Bookmarks))
-        val screenState = ScreenState(Screen.News)
-
-        val navigator = object : Navigator {
-            override fun navigateTo(screen: Screen) {
-                screenState.currentScreen = screen
+        val onboardingNavController = rememberNavController()
+        NavHost(navController = onboardingNavController, startDestination = Routes.Onboarding) {
+            composable(Routes.Onboarding) {
+                OnboardingContent(
+                    onboardingViewModel = onboardingViewModelLazy,
+                    onContinue = {
+                        onboardingViewModelLazy.value.onContinueClicked(token = it)
+                    },
+                    onApiTokenChange = {
+                        onboardingViewModelLazy.value.onApiTokenChange(token = it)
+                    },
+                )
+                val observeState = onboardingViewModelLazy.value.continueToApp.observeAsState()
+                if (observeState.value == true) {
+                    onboardingNavController.navigate(route = Routes.Main)
+                }
+            }
+            composable(Routes.Main) {
+                Main()
             }
         }
+    }
 
+    @Composable
+    private fun Main() {
+        val navController = rememberNavController()
+        val scaffoldState = rememberScaffoldState()
         Scaffold(
+            scaffoldState = scaffoldState,
             topBar = {
                 TopAppBar(
                     title = { Text(stringResource(R.string.app_name)) }
                 )
             },
-            bodyContent = {
-                when (screenState.currentScreen) {
-                    is Screen.News -> {
-                        NewsContent(
-                            newsViewModel = newsViewModelLazy,
-                            onItemClicked = {
-                                // Handle click listener
-                            }
-                        )
-                        newsViewModelLazy.value.fetchHeadlines()
-                    }
-                    else -> Unit
-                }
-
-            },
             bottomBar = {
                 BottomNavBar(
-                    state = navBarState,
-                    onItemSelected = {
-                        setBottomNavSelection(it, navigator)
-                    }
+                    navController = navController,
+                    items = listOf(NavItem.News, NavItem.Explore, NavItem.Bookmarks)
                 )
             }
-        )
+        ) {
+            NavHost(navController = navController, startDestination = Routes.News) {
+                composable(Routes.Explore) {
+                    Text(text = "Explore")
+                }
+                composable(Routes.Bookmarks) {
+                    Text(text = "Bookmarks")
+                }
+                composable(Routes.News) {
+                    NewsContent(
+                        newsViewModel = newsViewModelLazy,
+                        onItemClicked = {
+                            // Handle click listener
+                        }
+                    )
+                    LaunchedEffect(Routes.News) {
+                        newsViewModelLazy.value.fetchHeadlines()
+                    }
+                }
+            }
+        }
     }
 
-    private fun setBottomNavSelection(navItem: NavItem, navigator: Navigator): Boolean {
-        // navigate to corresponding screen
-        when (navItem) {
-            is NavItem.News -> navigator.navigateTo(Screen.News)
-            else -> Toast.makeText(this, "Not yet implemented ${navItem.index}", Toast.LENGTH_SHORT)
-                .show()
-        }
-        return true
-    }
 }

--- a/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/Navigation.kt
+++ b/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/Navigation.kt
@@ -1,0 +1,14 @@
+package com.segunfamisa.zeitung.ui.common
+
+object Routes {
+    private const val host = "zeitung"
+    val Onboarding = format("onboarding")
+    val Main = format("main")
+    val News = format("news")
+    val Explore = format("explore")
+    val Bookmarks = format("bookmarks")
+
+    private fun format(screen: String): String {
+        return "$host://$screen"
+    }
+}

--- a/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/Navigator.kt
+++ b/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/Navigator.kt
@@ -1,5 +1,0 @@
-package com.segunfamisa.zeitung.ui.common
-
-interface Navigator {
-    fun navigateTo(screen: Screen)
-}

--- a/android/onboarding/build.gradle
+++ b/android/onboarding/build.gradle
@@ -20,6 +20,8 @@ dependencies {
     implementation("androidx.compose.runtime:runtime-livedata:$libs.composeVersion")
 
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0")
+    implementation("io.arrow-kt:arrow-core:$libs.arrowVersion")
+    implementation("com.google.dagger:dagger:$libs.daggerVersion")
 
     implementation "com.google.dagger:dagger:$libs.daggerVersion"
 

--- a/android/onboarding/build.gradle
+++ b/android/onboarding/build.gradle
@@ -18,12 +18,11 @@ dependencies {
     implementation("androidx.ui:ui-tooling:$libs.composeVersion")
     implementation("androidx.compose.ui:ui:$libs.composeVersion")
     implementation("androidx.compose.runtime:runtime-livedata:$libs.composeVersion")
+    implementation("androidx.navigation:navigation-compose:$libs.navigationVersion")
 
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0")
     implementation("io.arrow-kt:arrow-core:$libs.arrowVersion")
     implementation("com.google.dagger:dagger:$libs.daggerVersion")
 
-    implementation "com.google.dagger:dagger:$libs.daggerVersion"
-
-    testImplementation "junit:junit:$testLibs.jUnitVersion"
+    testImplementation("junit:junit:$testLibs.jUnitVersion")
 }

--- a/android/onboarding/src/main/java/com/segunfamisa/zeitung/onboarding/OnboardingScreen.kt
+++ b/android/onboarding/src/main/java/com/segunfamisa/zeitung/onboarding/OnboardingScreen.kt
@@ -30,13 +30,15 @@ fun OnboardingContent(
     onContinue: (String) -> Unit,
     onApiTokenChange: (String) -> Unit
 ) {
-    val continueButtonEnabled =
-        onboardingViewModel.value.continueButtonEnabled.observeAsState(false)
-    OnboardingScreen(
-        continueButtonEnabled = continueButtonEnabled,
-        onContinue = onContinue,
-        onApiTokenChange = onApiTokenChange
-    )
+    Scaffold {
+        val continueButtonEnabled =
+            onboardingViewModel.value.continueButtonEnabled.observeAsState(false)
+        OnboardingScreen(
+            continueButtonEnabled = continueButtonEnabled,
+            onContinue = onContinue,
+            onApiTokenChange = onApiTokenChange
+        )
+    }
 }
 
 @Composable

--- a/android/onboarding/src/main/java/com/segunfamisa/zeitung/onboarding/OnboardingViewModel.kt
+++ b/android/onboarding/src/main/java/com/segunfamisa/zeitung/onboarding/OnboardingViewModel.kt
@@ -1,10 +1,10 @@
 package com.segunfamisa.zeitung.onboarding
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import arrow.core.Either
 import com.segunfamisa.zeitung.domain.credentials.SaveApiCredentialsUseCase
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
@@ -20,6 +20,10 @@ class OnboardingViewModel @Inject constructor(
     val continueButtonEnabled: LiveData<Boolean>
         get() = _continueButtonEnabled
 
+    private val _continueToApp: MutableLiveData<Boolean> = MutableLiveData()
+    val continueToApp: LiveData<Boolean>
+        get() = _continueToApp
+
     fun onApiTokenChange(token: String) {
         viewModelScope.launch {
             flowOf(token)
@@ -34,7 +38,10 @@ class OnboardingViewModel @Inject constructor(
         viewModelScope.launch {
             saveApiCredentialsUseCase.execute(param = token)
                 .collect {
-                    Log.d("Onboarding", "API token saved!")
+                    when (it) {
+                        is Either.Right -> _continueToApp.value = true
+                        else -> Unit
+                    }
                 }
         }
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,6 +18,7 @@ ext {
             arrowVersion           : "0.8.1",
             glideVersion           : "4.11.0",
             composeVersion         : "1.0.0-alpha07",
+            navigationVersion      : "1.0.0-alpha02",
             accompanistVersion     : "0.3.3.1"
     ]
 


### PR DESCRIPTION
This PR makes use of the Compose navigation extensions to implement navigation from one screen to the other.

Things to note here:
1. A navController can have only one host
2. We can declare routes - [see here for more](https://developer.android.com/jetpack/compose/navigation).
3. I think somehow, the routes are handled strangely, because when I had the following routes: `"main?news"` `"main?explore"`, `"main?saved"`, it failed to work. Until I had to rename those routes. I'm yet to investigate this, but I'll get back to it later.