### PR TITLE
Update compose version to 1.0.0-alpha09

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation("androidx.compose.foundation:foundation-layout:$libs.composeVersion")
     implementation("androidx.compose.material:material:$libs.composeVersion")
     implementation("androidx.compose.animation:animation:$libs.composeVersion")
-    implementation("androidx.ui:ui-tooling:$libs.composeVersion")
+    implementation("androidx.ui:ui-tooling:$libs.composeUiToolingVersion")
     implementation("androidx.compose.ui:ui:$libs.composeVersion")
     implementation("androidx.compose.runtime:runtime-livedata:$libs.composeVersion")
     implementation("androidx.navigation:navigation-compose:$libs.navigationVersion")

--- a/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/BottomNavBar.kt
+++ b/android/app/src/main/java/com/segunfamisa/zeitung/ui/common/BottomNavBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
@@ -61,7 +62,7 @@ private fun BottomNavIcon(
     navItem: NavItem
 ) {
     Icon(
-        asset = vectorResource(id = navItem.icon),
+        painter = painterResource(id = navItem.icon),
         modifier = Modifier,
     )
 }

--- a/android/headlines/build.gradle
+++ b/android/headlines/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation("androidx.compose.foundation:foundation-layout:$libs.composeVersion")
     implementation("androidx.compose.material:material:$libs.composeVersion")
     implementation("androidx.compose.animation:animation:$libs.composeVersion")
-    implementation("androidx.ui:ui-tooling:$libs.composeVersion")
+    implementation("androidx.ui:ui-tooling:$libs.composeUiToolingVersion")
     implementation("androidx.compose.ui:ui:$libs.composeVersion")
     implementation("androidx.compose.runtime:runtime-livedata:$libs.composeVersion")
 

--- a/android/news/build.gradle
+++ b/android/news/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation("androidx.compose.foundation:foundation-layout:$libs.composeVersion")
     implementation("androidx.compose.material:material:$libs.composeVersion")
     implementation("androidx.compose.animation:animation:$libs.composeVersion")
-    implementation("androidx.ui:ui-tooling:$libs.composeVersion")
+    implementation("androidx.ui:ui-tooling:$libs.composeUiToolingVersion")
     implementation("androidx.compose.ui:ui:$libs.composeVersion")
     implementation("androidx.compose.runtime:runtime-livedata:$libs.composeVersion")
 

--- a/android/news/src/main/java/com/segunfamisa/zeitung/news/NewsContent.kt
+++ b/android/news/src/main/java/com/segunfamisa/zeitung/news/NewsContent.kt
@@ -15,10 +15,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.gesture.longPressGestureFilter
-import androidx.compose.ui.graphics.imageFromResource
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ContextAmbient
-import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.ui.tooling.preview.Preview
 import com.segunfamisa.zeitung.common.NetworkImage
@@ -253,7 +252,7 @@ private fun ArticleImage(
 ) {
     item.image?.let {
         Image(
-            imageVector = it,
+            painter = it,
             modifier = modifier,
             contentScale = ContentScale.Crop
         )
@@ -277,12 +276,12 @@ private fun SaveButton(
     ) {
         if (isSaved) {
             Icon(
-                imageVector = vectorResource(id = R.drawable.ic_bookmark),
+                painter = painterResource(id = R.drawable.ic_bookmark),
                 tint = colors().secondary
             )
         } else {
             Icon(
-                imageVector = vectorResource(id = R.drawable.ic_bookmark_outlined)
+                painter = painterResource(id = R.drawable.ic_bookmark_outlined)
             )
         }
     }
@@ -390,7 +389,7 @@ fun fakeArticle() = UiNewsItem.Regular(
     subhead = "Square Enix ' s hit game returns as an anime",
     url = "https://www.nintendolife.com/news/2020/07/the_world_ends_with_you_the_animation_airs_in_2021_heres_your_first_look",
     isSaved = true,
-    image = null,
+    image = painterResource(id = R.drawable.nintendo),
     imageUrl = "https://thumbor.forbes.com/thumbor/fit-in/1200x0/filters%3Aformat%28jpg%29/https%3A%2F%2Fspecials-images.forbesimg.com%2Fimageserve%2F5ee95df165be0e00060a8bdd%2F0x0.jpg%3FcropX1%3D12%26cropX2%3D695%26cropY1%3D9%26cropY2%3D393",
     date = Date()
 )

--- a/android/news/src/main/java/com/segunfamisa/zeitung/news/NewsContent.kt
+++ b/android/news/src/main/java/com/segunfamisa/zeitung/news/NewsContent.kt
@@ -253,7 +253,7 @@ private fun ArticleImage(
 ) {
     item.image?.let {
         Image(
-            asset = it,
+            imageVector = it,
             modifier = modifier,
             contentScale = ContentScale.Crop
         )
@@ -277,12 +277,12 @@ private fun SaveButton(
     ) {
         if (isSaved) {
             Icon(
-                asset = vectorResource(id = R.drawable.ic_bookmark),
+                imageVector = vectorResource(id = R.drawable.ic_bookmark),
                 tint = colors().secondary
             )
         } else {
             Icon(
-                asset = vectorResource(id = R.drawable.ic_bookmark_outlined)
+                imageVector = vectorResource(id = R.drawable.ic_bookmark_outlined)
             )
         }
     }
@@ -292,7 +292,7 @@ private fun SaveButton(
 private fun LoadingScreen() {
     Box(
         modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center),
-        alignment = Alignment.Center
+        contentAlignment = Alignment.Center
     ) {
         CircularProgressIndicator(color = colors().secondary)
     }
@@ -390,10 +390,7 @@ fun fakeArticle() = UiNewsItem.Regular(
     subhead = "Square Enix ' s hit game returns as an anime",
     url = "https://www.nintendolife.com/news/2020/07/the_world_ends_with_you_the_animation_airs_in_2021_heres_your_first_look",
     isSaved = true,
-    image = imageFromResource(
-        ContextAmbient.current.resources,
-        R.drawable.nintendo
-    ),
+    image = null,
     imageUrl = "https://thumbor.forbes.com/thumbor/fit-in/1200x0/filters%3Aformat%28jpg%29/https%3A%2F%2Fspecials-images.forbesimg.com%2Fimageserve%2F5ee95df165be0e00060a8bdd%2F0x0.jpg%3FcropX1%3D12%26cropX2%3D695%26cropY1%3D9%26cropY2%3D393",
     date = Date()
 )

--- a/android/news/src/main/java/com/segunfamisa/zeitung/news/UiNewsItem.kt
+++ b/android/news/src/main/java/com/segunfamisa/zeitung/news/UiNewsItem.kt
@@ -1,6 +1,7 @@
 package com.segunfamisa.zeitung.news
 
-import androidx.compose.ui.graphics.ImageAsset
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.vector.ImageVector
 import java.util.*
 
 sealed class UiNewsItem(
@@ -10,7 +11,7 @@ sealed class UiNewsItem(
     open val date: Date,
     open val url: String,
     open val isSaved: Boolean,
-    open val image: ImageAsset?,
+    open val image: ImageVector?,
     open val imageUrl: String,
     open val source: UiSourceItem
 ) {
@@ -22,7 +23,7 @@ sealed class UiNewsItem(
         override val date: Date,
         override val url: String,
         override val isSaved: Boolean,
-        override val image: ImageAsset?,
+        override val image: ImageVector?,
         override val imageUrl: String,
         override val source: UiSourceItem
     ) : UiNewsItem(
@@ -44,7 +45,7 @@ sealed class UiNewsItem(
         override val date: Date,
         override val url: String,
         override val isSaved: Boolean,
-        override val image: ImageAsset?,
+        override val image: ImageVector?,
         override val imageUrl: String,
         override val source: UiSourceItem
     ) : UiNewsItem(
@@ -63,5 +64,5 @@ sealed class UiNewsItem(
 data class UiSourceItem(
     val id: String,
     val name: String,
-    val logo: ImageAsset?
+    val logo: ImageBitmap?
 )

--- a/android/news/src/main/java/com/segunfamisa/zeitung/news/UiNewsItem.kt
+++ b/android/news/src/main/java/com/segunfamisa/zeitung/news/UiNewsItem.kt
@@ -1,7 +1,7 @@
 package com.segunfamisa.zeitung.news
 
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.painter.Painter
 import java.util.*
 
 sealed class UiNewsItem(
@@ -11,7 +11,7 @@ sealed class UiNewsItem(
     open val date: Date,
     open val url: String,
     open val isSaved: Boolean,
-    open val image: ImageVector?,
+    open val image: Painter?,
     open val imageUrl: String,
     open val source: UiSourceItem
 ) {
@@ -23,7 +23,7 @@ sealed class UiNewsItem(
         override val date: Date,
         override val url: String,
         override val isSaved: Boolean,
-        override val image: ImageVector?,
+        override val image: Painter?,
         override val imageUrl: String,
         override val source: UiSourceItem
     ) : UiNewsItem(
@@ -45,7 +45,7 @@ sealed class UiNewsItem(
         override val date: Date,
         override val url: String,
         override val isSaved: Boolean,
-        override val image: ImageVector?,
+        override val image: Painter?,
         override val imageUrl: String,
         override val source: UiSourceItem
     ) : UiNewsItem(

--- a/android/onboarding/build.gradle
+++ b/android/onboarding/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     implementation("androidx.compose.foundation:foundation-layout:$libs.composeVersion")
     implementation("androidx.compose.material:material:$libs.composeVersion")
-    implementation("androidx.ui:ui-tooling:$libs.composeVersion")
+    implementation("androidx.ui:ui-tooling:$libs.composeUiToolingVersion")
     implementation("androidx.compose.ui:ui:$libs.composeVersion")
     implementation("androidx.compose.runtime:runtime-livedata:$libs.composeVersion")
     implementation("androidx.navigation:navigation-compose:$libs.navigationVersion")

--- a/android/onboarding/src/main/java/com/segunfamisa/zeitung/onboarding/OnboardingScreen.kt
+++ b/android/onboarding/src/main/java/com/segunfamisa/zeitung/onboarding/OnboardingScreen.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.savedinstancestate.savedInstanceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
@@ -57,7 +57,7 @@ fun OnboardingScreen(
         ) {
             Image(
                 modifier = Modifier.align(Alignment.CenterHorizontally),
-                imageVector = vectorResource(id = R.drawable.onboarding_icon)
+                painter = painterResource(id = R.drawable.onboarding_icon)
             )
             Spacer(modifier = Modifier.preferredHeight(16.dp))
             Text(

--- a/android/onboarding/src/main/java/com/segunfamisa/zeitung/onboarding/OnboardingScreen.kt
+++ b/android/onboarding/src/main/java/com/segunfamisa/zeitung/onboarding/OnboardingScreen.kt
@@ -50,14 +50,14 @@ fun OnboardingScreen(
     var apiKey by savedInstanceState(saver = TextFieldValue.Saver) { TextFieldValue() }
     Box(
         modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center),
-        alignment = Alignment.Center
+        contentAlignment = Alignment.Center
     ) {
         Column(
             modifier = Modifier.wrapContentSize(align = Alignment.Center).padding(72.dp)
         ) {
             Image(
                 modifier = Modifier.align(Alignment.CenterHorizontally),
-                asset = vectorResource(id = R.drawable.onboarding_icon)
+                imageVector = vectorResource(id = R.drawable.onboarding_icon)
             )
             Spacer(modifier = Modifier.preferredHeight(16.dp))
             Text(

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.0'
+    ext.kotlin_version = '1.4.21'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-alpha13'
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/config/android-compose-config.gradle
+++ b/config/android-compose-config.gradle
@@ -13,5 +13,6 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion "$tools.composeCompilerVersion"
+        kotlinCompilerVersion rootProject.ext.kotlin_version
     }
 }

--- a/config/android-config.gradle
+++ b/config/android-config.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-android-extensions'
 def sdk = rootProject.ext.sdkVersions
 android {
     compileSdkVersion sdk.compileSdkVersion
-    buildToolsVersion sdk.buildToolsVersion
     defaultConfig {
         minSdkVersion sdk.minSdkVersion
         targetSdkVersion sdk.targetSdkVersion

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,8 +17,9 @@ ext {
             daggerVersion          : "2.27",
             arrowVersion           : "0.8.1",
             glideVersion           : "4.11.0",
-            composeVersion         : "1.0.0-alpha07",
-            navigationVersion      : "1.0.0-alpha02",
+            composeVersion         : "1.0.0-alpha09",
+            composeUiToolingVersion: "1.0.0-alpha07",
+            navigationVersion      : "1.0.0-alpha04",
             accompanistVersion     : "0.3.3.1"
     ]
 
@@ -34,6 +35,6 @@ ext {
     tools = [
             ktlintVersion          : "0.29.0",
             detektVersion          : "1.0.0-RC11",
-            composeCompilerVersion : "1.0.0-alpha07"
+            composeCompilerVersion : "1.0.0-alpha09"
     ]
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
             composeVersion         : "1.0.0-alpha09",
             composeUiToolingVersion: "1.0.0-alpha07",
             navigationVersion      : "1.0.0-alpha04",
-            accompanistVersion     : "0.3.3.1"
+            accompanistVersion     : "0.4.1"
     ]
 
     testLibraryVersions = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8-rc-1-all.zip


### PR DESCRIPTION
This PR updates compose to version `1.0.0-alpha09`

Major impacts of that update include:

1. Updating accompanist to `v0.4.1`
2. Updating Kotlin to `1.4.21`
3. Update navigation to `1.0.0-alpha04`
4. Since it looks like `ImagesAsset` is being retired, and replaced with `ImageBitmap` and `ImageVector` for regular bitmap and vectors respectively, it's advisable to use `Painter` as opposed to bitmap or vectors. See [commit here](https://android-review.googlesource.com/q/Ia2d9941a6e0b8c29867cb3fbafb629fa4db10684)